### PR TITLE
Show power status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ https://www.claudiokuenzler.com/monitoring-plugins/check_shelly.php
 
 ### API Resources
 https://shelly-api-docs.shelly.cloud/
+
+
+### Example output
+
+```
+SHELLY OK: Device (shellyplus1pm-xxx) SWITCH_0 is on, currently using 0 Watt / 0 Amp |power=0 current=0 total_power=50.982 temp=46.2 powerstatus=1
+```

--- a/check_shelly.py
+++ b/check_shelly.py
@@ -186,9 +186,10 @@ elif checktype == "meter":
     # aenergy by minute: array of numbers, energy consumption by minute (in Milliwatt-hours) for the last three minutes (the lower the index of the element in the array, the closer to the current moment the minute)
     aenergy_by_minute = data['result']['aenergy']['by_minute']
     temp_celsius = data['result']['temperature']['tC']
+    powerstatus = data['result']['output']
 
-    output="SHELLY OK: Device (%s) SWITCH_%i, currently using %i Watt / %i Amp" % (devicename, shelly_switch, apower, current)
-    perfdata="|power=%i current=%i total_power=%.3f temp=%.1f" % (apower, current, aenergy_total, temp_celsius)
+    output="SHELLY OK: Device (%s) SWITCH_%i is %s, currently using %i Watt / %i Amp" % (devicename, shelly_switch, "on" if powerstatus else "off", apower, current)
+    perfdata="|power=%i current=%i total_power=%.3f temp=%.1f powerstatus=%i" % (apower, current, aenergy_total, temp_celsius, 1 if powerstatus else 0)
     systemexit(exit_status, output, perfdata)
 
 else:

--- a/check_shelly.py
+++ b/check_shelly.py
@@ -7,16 +7,16 @@
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or 
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>. 
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 # Copyright (c) 2022 Claudio Kuenzler www.claudiokuenzler.com
 #
@@ -112,7 +112,7 @@ if checktype == "info":
     auth_en = data['auth_en']
     if auth_en:
         authinfo="Authentication is enabled"
-    else: 
+    else:
         authinfo="Authentication is disabled"
 
     output= "SHELLY OK: Device %s (Model: %s, Generation: %s, Firmware: %s) is running - %s" % (devicename, model, gen, fwversion, authinfo)
@@ -152,7 +152,7 @@ elif checktype == "system":
         output_warning="SHELLY WARNING: Device (%s) requires a restart" % (devicename)
         exit_status=1
 
-    if (exit_status > 1): 
+    if (exit_status > 1):
         output=output_critical
     elif (exit_status > 0):
         output=output_warning
@@ -163,13 +163,13 @@ elif checktype == "system":
     systemexit(exit_status, output, perfdata)
 
 elif checktype == "meter":
-    postdata = { "id": 1, "method": "Switch.GetStatus", "params": {"id": shelly_switch} } 
+    postdata = { "id": 1, "method": "Switch.GetStatus", "params": {"id": shelly_switch} }
     if auth:
         try:
             r = requests.post(apiurl, json=postdata, auth=HTTPDigestAuth(args.user, args.password))
         except OSError as err:
             systemexit(2, "SHELLY CRITICAL: {0}".format(err), "")
-    else: 
+    else:
         try:
             r = requests.post(apiurl, json=postdata)
         except OSError as err:


### PR DESCRIPTION
The power status of the switch is shown in the output now.
Besides that, the power status is available as perfdata.

I've named it `powerstatus` as variable, and performance data.

Fixes #3.

There's a 2nd commit in this PR, removing the trailing white space in some lines. My editor (Atom) removes the spaces automatically. I hope you're fine with this. 