### PR TITLE
Check powerstate of switch

### DIFF
--- a/check_shelly.py
+++ b/check_shelly.py
@@ -40,7 +40,7 @@ ignore_restart=False
 shelly_model="Pro4PM"
 shelly_switch=0
 exit_status=0
-powerstate=-1
+expect_powerstatus=-1
 
 # Input parameters
 description = "check_shelly v%s - Monitoring Plugin for Shelly 2nd gen power devices" % version
@@ -53,7 +53,7 @@ parser.add_argument('-t', '--type', dest='checktype', required=True, choices=['i
 parser.add_argument('-m', '--model', dest='shelly_model', help='Hardware model of Shelly device (defaults to Pro4PM)')
 parser.add_argument('-s', '--switch', dest='shelly_switch', type=int, help='Select the switch id of this Shelly device (e.g. switch_0 would be 0, defaults to 0)')
 parser.add_argument('--ignore-restart', dest='ignore_restart', action='store_true', help='Ignore the fact that the device requires a restart')
-parser.add_argument('--powerstate', dest='powerstate', choices=['0','1','off','on'], help='Check for powerstate of the switch, raises a warning state if different, requires --type=meter')
+parser.add_argument('--expect-powerstatus', dest='expect_powerstatus', choices=['0','1','off','on'], help='Check for powerstatus of the switch, raises a warning state if different, requires --type=meter')
 args = parser.parse_args()
 
 # Handle inputs, overwrite defaults
@@ -81,8 +81,8 @@ if (args.ignore_restart):
 if (args.checktype):
     checktype=args.checktype
 
-if (args.powerstate):
-    powerstate=args.powerstate
+if (args.expect_powerstatus):
+    expect_powerstatus=args.expect_powerstatus
 
 # Handle different Shelly device models (shelly_model) or device generations
 # todo: maybe this can be used in the future
@@ -193,8 +193,8 @@ elif checktype == "meter":
     temp_celsius = data['result']['temperature']['tC']
     powerstatus = data['result']['output']
 
-    # If actual powerstatus is not the desired powerstate then raise warning
-    if ( (powerstate == "1" or powerstate == "on") and not powerstatus) or ( (powerstate == "0" or powerstate == "off") and powerstatus):
+    # If actual powerstatus is not the expected powerstatus then raise warning
+    if ( (expect_powerstatus == "1" or expect_powerstatus == "on") and not powerstatus) or ( (expect_powerstatus == "0" or expect_powerstatus == "off") and powerstatus):
         exit_status=1
 
     if (exit_status == 0):

--- a/check_shelly.py
+++ b/check_shelly.py
@@ -40,7 +40,7 @@ ignore_restart=False
 shelly_model="Pro4PM"
 shelly_switch=0
 exit_status=0
-expect_powerstatus=-1
+expect_powerstatus=None
 
 # Input parameters
 description = "check_shelly v%s - Monitoring Plugin for Shelly 2nd gen power devices" % version
@@ -82,7 +82,7 @@ if (args.checktype):
     checktype=args.checktype
 
 if (args.expect_powerstatus):
-    expect_powerstatus=args.expect_powerstatus
+    expect_powerstatus=True if args.expect_powerstatus == "1" or args.expect_powerstatus == "on" else False
 
 # Handle different Shelly device models (shelly_model) or device generations
 # todo: maybe this can be used in the future
@@ -194,8 +194,9 @@ elif checktype == "meter":
     powerstatus = data['result']['output']
 
     # If actual powerstatus is not the expected powerstatus then raise warning
-    if ( (expect_powerstatus == "1" or expect_powerstatus == "on") and not powerstatus) or ( (expect_powerstatus == "0" or expect_powerstatus == "off") and powerstatus):
-        exit_status=1
+    if expect_powerstatus != None:
+        if expect_powerstatus != powerstatus:
+            exit_status=1
 
     if (exit_status == 0):
         state_text = "OK"

--- a/check_shelly.py
+++ b/check_shelly.py
@@ -83,6 +83,9 @@ if (args.checktype):
 
 if (args.expect_powerstatus):
     expect_powerstatus=True if args.expect_powerstatus == "1" or args.expect_powerstatus == "on" else False
+    if checktype != "meter":
+        print("SHELLY UNKNOWN: expect-powerstatus requires check type 'meter'")
+        sys.exit(3)
 
 # Handle different Shelly device models (shelly_model) or device generations
 # todo: maybe this can be used in the future

--- a/check_shelly.py
+++ b/check_shelly.py
@@ -198,6 +198,7 @@ elif checktype == "meter":
         if expect_powerstatus != powerstatus:
             exit_status=1
 
+    # Set state text for monitoring ("SHELLY WARNING" etc.)
     if (exit_status == 0):
         state_text = "OK"
     elif (exit_status == 1):


### PR DESCRIPTION
You can check the powerstate of the switch. Pass `--powerstate on` as  command line argument, and the script will give you a warning state when  the Shelly switch is powered off.

This PR relates to #2.

Some notes about the commit:

- I'm not very familiar using Python. Hopefully you're not getting mad when you see my code.
- `exit_state` is set to 1 without any further checks (this will break things when there's a check for a critical state in the future)

I wanted to share the code early. 

Feedback much appreciated.