### PR TITLE
Fix r_status undefined error in system

### DIFF
--- a/check_shelly.py
+++ b/check_shelly.py
@@ -162,6 +162,7 @@ if checktype == "info":
 
 elif checktype == "system":
     postdata = {'id':1, 'method':'Sys.GetStatus'}
+    r_status = None
     if auth:
         try:
             r = requests.post(apiurl, json=postdata, auth=AuthenticationMethod(args.user, args.password))


### PR DESCRIPTION
When switching from v0.1 to v0.3, my checktype == "system" checks raise an error:

```
Traceback (most recent call last): File "/usr/local/bin/check_shelly_0.3.py", line 179, in if r_status: ^^^^^^^^ NameError: name 'r_status' is not defined
```

r_status is not defined. This commit fixes that.

Disclaimer: I'm not a python expert.